### PR TITLE
add /compile_commands.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@
 # macos
 .DS_Store
 xcuserdata/
+
+/compile_commands.json


### PR DESCRIPTION
JSON compilation database for C/CPP Vim IDE support